### PR TITLE
添加对mkimage的报错说明

### DIFF
--- a/docs/source/uboot.rst
+++ b/docs/source/uboot.rst
@@ -178,9 +178,12 @@ UBoot的这种设计为开发带来了极大的灵活性，我们可以只烧写
 
 .. sourcecode:: bash
 
-	mkimage -f linux.its kernel_fdt.itb
+	./tools/mkimage -f linux.its kernel_fdt.itb
 	# 烧写镜像
 	sudo dd if=kernel_fdt.itb of=/dev/sdb bs=512 seek=2048; sync
+
+如果在执行mkimage时提示`sh: 1: dtc: not found`,说明没有安装`device-tree-compiler`,debian系可以通过`sudo apt-get install device-tree-compiler
+`进行安装
 
 .. tools/mkimage -n  imxcfg.imx -T imximage -e 0x17800000 -d u-boot.bin u-boot.imx
 


### PR DESCRIPTION
如果没有安装device-tree-compiler的话会有报错提示.
添加mkimage的路径说明 该可执行文件在uboot/tools下