### PR TITLE
change the file docs/source/kernel.rst, delete to letter

### DIFF
--- a/docs/source/kernel.rst
+++ b/docs/source/kernel.rst
@@ -55,7 +55,7 @@ Linux内核使用指南
 	git checkout -b blurr-4.1.15 origin/blurr-4.1.15 #切换分支
 	# 编译内核
 	ARCH=arm make blurr_defconfig #配置内核
-	ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- make -j8 #编译内核，生成zImage和dtb文件
+	ARCH=arm CROSS_COMPILE=arm-linux-gnueabi- make -j8 #编译内核，生成zImage和dtb文件
 	# -j8指定你的cpu核数×2，即我的cpu核数为4，但也可不指定。
 	
 烧录


### PR DESCRIPTION
## 修改了一个笔误
- 在环境搭建过程并没有 `sudo apt-get install gcc-arm-linux-gnueabihf`
- 后面如果执行命令`ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- make`就报错找不到这个编译器
- 把编译器指定为前面`install`过的`gcc-arm-linux-gnueabi`
- 所以命令改为`ARCH=arm CROSS_COMPILE=arm-linux-gnueabi- make -j8`